### PR TITLE
fix(environment): update Docker image for Dask compatibility

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -44,7 +44,7 @@ rule all:
 
 rule process_sample_one_file_in_sample:
     container:
-        "docker.io/reanahub/reana-demo-agc-cms-ttbar-coffea:1.0.0"
+        "docker.io/reanahub/reana-demo-agc-cms-ttbar-coffea:1.0.1"
     resources:
         kubernetes_memory_limit="1850Mi"
     input:
@@ -54,13 +54,12 @@ rule process_sample_one_file_in_sample:
     params:
         sample_name = "{sample}__{condition}"
     shell:
-        "/bin/bash -l && source fix-env.sh && "
         "papermill {input.notebook} $(python prepare_workspace.py sample_{params.sample_name}_{wildcards.index})/sample_{params.sample_name}_{wildcards.index}_out.ipynb "
         "-p sample_name {params.sample_name} -p index {wildcards.index} -k python3"
 
 rule process_sample:
     container:
-        "docker.io/reanahub/reana-demo-agc-cms-ttbar-coffea:1.0.0"
+        "docker.io/reanahub/reana-demo-agc-cms-ttbar-coffea:1.0.1"
     resources:
         kubernetes_memory_limit="1850Mi"
     input:
@@ -71,11 +70,11 @@ rule process_sample:
     params:
         sample_name = '{sample}__{condition}'
     shell:
-        "/bin/bash -l && source fix-env.sh && papermill {input.notebook} merged_{params.sample_name}.ipynb -p sample_name {params.sample_name} -k python3"
+        "papermill {input.notebook} merged_{params.sample_name}.ipynb -p sample_name {params.sample_name} -k python3"
 
 rule merging_histograms:
     container:
-        "docker.io/reanahub/reana-demo-agc-cms-ttbar-coffea:1.0.0"
+        "docker.io/reanahub/reana-demo-agc-cms-ttbar-coffea:1.0.1"
     resources:
         kubernetes_memory_limit="1850Mi"
     input:
@@ -92,6 +91,6 @@ rule merging_histograms:
     output:
         "histograms.root"
     shell:
-        "/bin/bash -l && source fix-env.sh && papermill {input.notebook} result_notebook.ipynb -k python3"
+        "papermill {input.notebook} result_notebook.ipynb -k python3"
 
     

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -14,7 +14,7 @@ COPY requirements.lock /docker/requirements.lock
 RUN yum install -y bzip2 && \
     yum clean all && \
     yum autoremove -y && \
-    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba && \
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/1.5.9 | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba && \
     micromamba shell init --prefix /opt/micromamba --shell bash && \
     /usr/local/bin/micromamba shell init --prefix /opt/micromamba && \
     cp /root/.bashrc /etc/.bashrc && \
@@ -54,8 +54,6 @@ RUN mkdir -p -v /etc/condor && \
     ln -s /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
     mkdir -p -v /.local /.jupyter /.config /.cache /work && \
     chmod --recursive 777 /.local /.jupyter /.config /.cache /work && \
-    printf '#!/bin/bash\n\njupyter lab --no-browser --ip 0.0.0.0 --port 8888\n' > /docker/entrypoint.sh && \
-    chmod 777 /docker/entrypoint.sh && \
     echo 'export JUPYTER_PATH="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_PATH}"' >> /etc/.bashrc && \
     echo 'export JUPYTER_DATA_DIR="/opt/micromamba/envs/analysis-systems/share/jupyter"' >> /etc/.bashrc && \
     chmod --recursive 777 /opt/micromamba/envs/analysis-systems/share/jupyter && \
@@ -65,15 +63,6 @@ WORKDIR /work
 
 ENV HOME=/work
 
-SHELL ["/bin/bash", "-lc"]
+ENV PATH="/opt/micromamba/envs/analysis-systems/bin/:${PATH}"
 
-# Installing papermill for 
-RUN micromamba install papermill --channel conda-forge 
-
-
-COPY entrypoint.sh /entrypoint.sh  
-RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
-
-CMD ["/docker/entrypoint.sh"]
+RUN /bin/bash -l -c "micromamba install papermill --channel conda-forge"

--- a/environment/entrypoint.sh
+++ b/environment/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /bin/bash -l -c "$*"

--- a/fix-env.sh
+++ b/fix-env.sh
@@ -1,1 +1,0 @@
-export PATH="/opt/micromamba/envs/analysis-systems/bin/:$PATH"

--- a/reana.yaml
+++ b/reana.yaml
@@ -1,15 +1,12 @@
-version: 0.8.0
 inputs:
   files:
-    - ttbar_analysis_reana.ipynb 
+    - ttbar_analysis_reana.ipynb
     - nanoaod_inputs.json
-    - fix-env.sh
     - corrections.json
     - Snakefile
     - file_merging.ipynb
     - final_merging.ipynb
     - prepare_workspace.py
-
   directories:
     - histograms
     - utils


### PR DESCRIPTION
## Improve PATH Handling for AGC Workflow

To run the AGC workflow, we currently use the `fix-env.sh` utility script to update the PATH variable. This solution works for reana-run-job-xxx pods but does not apply to reana-run-dask-xxx pods since their startup command does not include fix-env.sh.

To address this, we now update the `PATH` variable directly in the Dockerfile. This approach ensures that Dask pods also have the correct PATH, eliminating the need for the `fix-env.sh` workaround.

### Note:
The root cause of this issue is that the Dockerfile updates the `PATH` required for Micromamba environments via `.bashrc`. However, REANA does not run containers with their respective startup scripts due to security reasons which means defining `.bashrc` configurations in Dockerfile is useless.