### PR TITLE
fix(git): ignore Snakemake runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.snakemake/


### PR DESCRIPTION
Exclude the .snakemake directory created during local workflow
execution. Snakemake uses it to store runtime state, metadata, locks,
logs and other machine-local files.

Keep local workflow runs from showing up as untracked repository
changes.
